### PR TITLE
Standardize error messages

### DIFF
--- a/api/presenter/error.go
+++ b/api/presenter/error.go
@@ -1,23 +1,54 @@
 package presenter
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gofiber/fiber/v2"
 )
 
-func ErrorResponse(c *fiber.Ctx, httpStatus int, err error) error {
-	return c.Status(httpStatus).JSON(fiber.Map{"error": err.Error()})
+type errorMessage struct {
+	Error   string      `json:"error"`
+	Message string      `json:"message"`
+	Details interface{} `json:"details"`
 }
 
-func InternalServerErrorResponse(c *fiber.Ctx, err error) error {
-	return ErrorResponse(c, http.StatusInternalServerError, err)
+func ErrorResponse(c *fiber.Ctx, httpStatus int, message string, details interface{}) error {
+	return c.Status(httpStatus).JSON(errorMessage{
+		Error:   http.StatusText(httpStatus),
+		Message: message,
+		Details: details,
+	})
 }
 
-func BadRequestResponse(c *fiber.Ctx, err error) error {
-	return ErrorResponse(c, http.StatusBadRequest, err)
+func InternalServerErrorResponse(c *fiber.Ctx) error {
+	requestId := c.Locals("requestid").(string)
+
+	return ErrorResponse(c, http.StatusInternalServerError,
+		"An error occurred on the server.",
+		fmt.Sprintf("An internal server error occurred. Please contact the administrator and provide the following request ID: %s.", requestId))
 }
 
-func NotFoundResponse(c *fiber.Ctx, err error) error {
-	return ErrorResponse(c, http.StatusNotFound, err)
+func UnprocessableEntityResponse(c *fiber.Ctx, message string, details interface{}) error {
+	return ErrorResponse(c, http.StatusUnprocessableEntity, message, details)
+}
+
+func ConflictResponse(c *fiber.Ctx, message string, details string) error {
+	return ErrorResponse(c, http.StatusConflict, message, details)
+}
+
+func BadRequestResponse(c *fiber.Ctx, message string, details string) error {
+	return ErrorResponse(c, http.StatusBadRequest, message, details)
+}
+
+func NotFoundResponse(c *fiber.Ctx, message string, details string) error {
+	return ErrorResponse(c, http.StatusNotFound, message, details)
+}
+
+func ForbiddenResponse(c *fiber.Ctx, message string, details string) error {
+	return ErrorResponse(c, http.StatusForbidden, message, details)
+}
+
+func UnauthorizedResponse(c *fiber.Ctx, message string, details string) error {
+	return ErrorResponse(c, http.StatusUnauthorized, message, details)
 }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -124,7 +124,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DHCPHost'
-        400:
+        422:
           description: Invalid input
           content:
             application/json:
@@ -159,7 +159,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DHCPHost'
-        400:
+        409:
+          description: The given IP/MAC address is already being used by another host
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        422:
           description: Invalid input
           content:
             application/json:
@@ -209,12 +215,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        404:
-          description: Host not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal server error
           content:
@@ -246,12 +246,35 @@ components:
           format: hostname
           example: foo.bar
 
+    FieldError:
+      type: object
+      properties:
+        field:
+          type: string
+          example: MacAddress
+        reason:
+          type: string
+          example: The MacAddress must be of type mac.
+        value:
+          type: string
+          example: "co:ff:ee:co:ff:ee"
+
     ErrorResponse:
       type: object
       properties:
         error:
           type: string
-          example: something went wrong
+          example: Bad Request
+        message:
+          type: string
+          example: The request is invalid.
+        details:
+          oneOf:
+            - type: string
+              example: The request could not be processed because the host could not be parsed. Please check the request and try again.
+            - type: array
+              items:
+                $ref: '#/components/schemas/FieldError'
 
   securitySchemes:
     jwtToken:

--- a/pkg/host/repository.go
+++ b/pkg/host/repository.go
@@ -118,7 +118,16 @@ func (r *repository) save(hosts *[]model.StaticDhcpHost) error {
 		config = append(config, host.ToConfig())
 	}
 
-	return os.WriteFile(r.staticHostsFilePath, []byte(strings.Join(config, "\n")), os.FileMode(0644))
+	err := os.WriteFile(r.staticHostsFilePath, []byte(strings.Join(config, "\n")), os.FileMode(0644))
+	if err != nil {
+		slog.Error("Error writing into the static hosts file",
+			slog.String("file", r.staticHostsFilePath),
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+
+	return nil
 }
 
 func (r *repository) delete(filter Filter) (*model.StaticDhcpHost, error) {


### PR DESCRIPTION
Use standard JSON formatted messages for error returns on all API calls. All the error messages are internally generated by the application and all external errors are now only logged with proper severity and them a generic message is presented to the user, avoiding exposing internal details due to security concerns.

The error now follows this structure:
```json
{
  "error": "The error code.",
  "message": "A human-readable message describing the error.",
  "details": "A more detailed explanation of the error, which can be
      used by administrators/maintainers to troubleshoot the issue."
}
```