### PR TITLE
Project rebranding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ go.work
 dist/
 
 # Application binary
-pi-hole-manager
+./dnsmasq-manager
 
 # Manual testing configuration files
 *.conf

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,8 +46,8 @@ changelog:
 nfpms:
   - id: default
     maintainer: Filipe Utzig <filipe@gringolito.com>
-    homepage: https://github.com/gringolito/pi-hole-manager
-    description: Pi-Hole Local DNS / DHCP management external API.
+    homepage: https://github.com/gringolito/dnsmasq-manager
+    description: Dnsmasq DNS / DHCP management external API.
     license: Beer-ware
     formats:
       - deb
@@ -57,17 +57,17 @@ nfpms:
     bindir: /usr/bin
     contents:
       - src: api/spec/openapi.yaml
-        dst: /usr/share/pi-hole-manager/spec/openapi.yaml
+        dst: /usr/share/dnsmasq-manager/spec/openapi.yaml
       - src: config.yaml.dist
-        dst: /etc/pi-hole-manager/config.yaml
+        dst: /etc/dnsmasq-manager/config.yaml
         type: config
         file_info:
           mode: 0640
-      - src: systemd/pi-hole-manager.service
-        dst: /etc/systemd/system/pi-hole-manager.service
+      - src: systemd/dnsmasq-manager.service
+        dst: /etc/systemd/system/dnsmasq-manager.service
         type: config
-      - src: systemd/pi-hole-manager
-        dst: /etc/default/pi-hole-manager
+      - src: systemd/dnsmasq-manager
+        dst: /etc/default/dnsmasq-manager
         type: config
       - src: scripts/generate-jwt-keys.sh
         dst: /usr/bin/generate-jwt-keys

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
-# pi-hole-manager
+# dnsmasq-manager
 
-Pi-Hole Local DNS / DHCP management API
+Dnsmasq DNS / DHCP management API
 
-This project provides a RESTful API to manage some of the DHCP/DNS resources on a pi-hole
-installation, like:
+This project provides a RESTful API to manage some of the DHCP/DNS resources on a dnsmasq
+server, like:
 
 - Manage static DHCP entries
-- Manage local DNS entries
+- Manage static DNS entries
 - Manage CNAME aliases
-
-We are not interested on managing the Adlists, Whitelists, Query logs or any other primary
-functionality of the pi-hole or the FTL.
 
 ## TO-DO
 
@@ -30,5 +27,5 @@ functionality of the pi-hole or the FTL.
 
 ### Phase-2
 
-- [ ] Manage local DNS entries
+- [ ] Manage static DNS entries
 - [ ] Manage CNAME alias

--- a/api/authentication.go
+++ b/api/authentication.go
@@ -9,8 +9,8 @@ import (
 
 	jwtware "github.com/gofiber/contrib/jwt"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gringolito/pi-hole-manager/api/presenter"
-	"github.com/gringolito/pi-hole-manager/config"
+	"github.com/gringolito/dnsmasq-manager/api/presenter"
+	"github.com/gringolito/dnsmasq-manager/config"
 	"golang.org/x/exp/slog"
 )
 

--- a/api/authorization.go
+++ b/api/authorization.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/gringolito/pi-hole-manager/api/presenter"
+	"github.com/gringolito/dnsmasq-manager/api/presenter"
 	"golang.org/x/exp/slices"
 	"golang.org/x/exp/slog"
 )

--- a/api/dto/static_dhcp_host.go
+++ b/api/dto/static_dhcp_host.go
@@ -3,7 +3,7 @@ package dto
 import (
 	"net"
 
-	"github.com/gringolito/pi-hole-manager/pkg/model"
+	"github.com/gringolito/dnsmasq-manager/pkg/model"
 )
 
 type StaticDhcpHost struct {

--- a/api/handler/host_handler.go
+++ b/api/handler/host_handler.go
@@ -6,11 +6,11 @@ import (
 	"net/http"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/gringolito/pi-hole-manager/api/dto"
-	"github.com/gringolito/pi-hole-manager/api/presenter"
-	"github.com/gringolito/pi-hole-manager/api/validation"
-	"github.com/gringolito/pi-hole-manager/pkg/host"
-	"github.com/gringolito/pi-hole-manager/pkg/model"
+	"github.com/gringolito/dnsmasq-manager/api/dto"
+	"github.com/gringolito/dnsmasq-manager/api/presenter"
+	"github.com/gringolito/dnsmasq-manager/api/validation"
+	"github.com/gringolito/dnsmasq-manager/pkg/host"
+	"github.com/gringolito/dnsmasq-manager/pkg/model"
 	"golang.org/x/exp/slog"
 )
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -5,8 +5,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/recover"
 	"github.com/gofiber/fiber/v2/middleware/requestid"
-	"github.com/gringolito/pi-hole-manager/api/middleware/fiberslog"
-	"github.com/gringolito/pi-hole-manager/config"
+	"github.com/gringolito/dnsmasq-manager/api/middleware/fiberslog"
+	"github.com/gringolito/dnsmasq-manager/config"
 	"golang.org/x/exp/slog"
 )
 

--- a/api/router.go
+++ b/api/router.go
@@ -3,10 +3,10 @@ package api
 import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/monitor"
-	"github.com/gringolito/pi-hole-manager/api/handler"
-	"github.com/gringolito/pi-hole-manager/api/middleware/fiberswagger"
-	"github.com/gringolito/pi-hole-manager/api/scope"
-	"github.com/gringolito/pi-hole-manager/pkg/host"
+	"github.com/gringolito/dnsmasq-manager/api/handler"
+	"github.com/gringolito/dnsmasq-manager/api/middleware/fiberswagger"
+	"github.com/gringolito/dnsmasq-manager/api/scope"
+	"github.com/gringolito/dnsmasq-manager/pkg/host"
 )
 
 type Router struct {

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -1,23 +1,23 @@
 openapi: 3.0.1
 info:
-  title: Pi-Hole Manager
+  title: Dnsmasq Manager
   description: |-
-    Pi-Hole Local DNS / DHCP management API
+    Dnsmasq DNS / DHCP management API
 
-    This API provides methods to manage some of the DHCP/DNS resources on a pi-hole server:
+    This API provides methods to manage some of the DHCP/DNS resources on a dnsmasq server:
 
       - Static DHCP entries
-      - Local DNS entries
+      - Static DNS entries
       - CNAME aliases
 
 
         Some useful links:
-    - [Pi-Hole Manager repository](https://github.com/gringolito/pi-hole-manager)
+    - [Dnsmasq Manager repository](https://github.com/gringolito/dnsmasq-manager)
   contact:
     email: filipe@gringolito.com
   license:
     name: Beerware
-    url: https://raw.githubusercontent.com/gringolito/pi-hole-manager/master/LICENSE
+    url: https://raw.githubusercontent.com/gringolito/dnsmasq-manager/master/LICENSE
   version: 0.1.0
 
 servers:
@@ -36,7 +36,7 @@ paths:
       tags:
       - Static hosts
       summary: Get all the static DHCP hosts
-      description: Return the list of all static DHCP entries on the pi-hole server
+      description: Return the list of all static DHCP entries on the dnsmasq server
       operationId: GetAllStaticHosts
       responses:
         200:

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -1,9 +1,9 @@
-# Uncomment this config block to set the Pi-Hole static DHCP hosts file.
-# Defaults to: /etc/dnsmasq.d/04-pihole-static-dhcp.conf
+# Uncomment this config block to set the dnsmasq static DHCP hosts file.
+# Defaults to: /etc/dnsmasq.d/04-dhcp-static-leases.conf
 #
 # host:
 #   static:
-#     file: /etc/dnsmasq.d/04-pihole-static-dhcp.conf
+#     file: /etc/dnsmasq.d/04-dhcp-static-leases.conf
 
 # Uncomment this config block to set JWT-based authentication configuration for API endpoints.
 # Available methods: none, ecdsa-256, ecdsa-384, ecdsa-512, hmac-256, hmac-384, hmac-512, rsa-256,
@@ -13,7 +13,7 @@
 #
 # auth:
 #   method: ecdsa-512
-#   key: /etc/pi-hole-manager/id_ecdsa.pub
+#   key: /etc/dnsmasq-manager/id_ecdsa.pub
 
 # Uncomment this config block to change the server HTTP listening port.
 # Defaults to: 6904
@@ -29,5 +29,5 @@
 # log:
 #   level: info
 #   format: json
-#   file: /var/log/pi-hole-manager.log
+#   file: /var/log/dnsmasq-manager.log
 #   source: false

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ const (
 
 // Other default constants
 const (
-	DefaultDhcpStaticHostFile = "/etc/dnsmasq.d/04-pihole-static-dhcp.conf"
+	DefaultDhcpStaticHostFile = "/etc/dnsmasq.d/04-dhcp-static-leases.conf"
 	DefaultServerHttpPort     = 6904
 )
 
@@ -73,11 +73,11 @@ func newDefaultConfig() *Config {
 }
 
 func Init(configName string) (*Config, error) {
-	viper.AddConfigPath("/etc/pi-hole-monitor/")
+	viper.AddConfigPath("/etc/dnsmasq-manager/")
 	viper.AddConfigPath(".")
 	viper.SetConfigType("yaml")
 	viper.SetConfigName(configName)
-	viper.SetEnvPrefix("PHM") // PHM stands for Pi-Hole Manager
+	viper.SetEnvPrefix("DMM") // DMM stands for (d)ns(m)asq (M)anager
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 	err := viper.ReadInConfig()

--- a/dnsmasq-manager.go
+++ b/dnsmasq-manager.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/monitor"
-	"github.com/gringolito/pi-hole-manager/api"
-	"github.com/gringolito/pi-hole-manager/config"
-	"github.com/gringolito/pi-hole-manager/pkg/host"
+	"github.com/gringolito/dnsmasq-manager/api"
+	"github.com/gringolito/dnsmasq-manager/config"
+	"github.com/gringolito/dnsmasq-manager/pkg/host"
 	"golang.org/x/exp/slog"
 )
 
 const (
-	AppName    = "Pi-Hole Manager"
+	AppName    = "dnsmasq Manager"
 	AppVersion = "v0.1.0"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gringolito/pi-hole-manager
+module github.com/gringolito/dnsmasq-manager
 
 go 1.20
 

--- a/pkg/host/repository.go
+++ b/pkg/host/repository.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gringolito/pi-hole-manager/pkg/model"
+	"github.com/gringolito/dnsmasq-manager/pkg/model"
 	"golang.org/x/exp/slog"
 )
 

--- a/pkg/host/service.go
+++ b/pkg/host/service.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/gringolito/pi-hole-manager/pkg/model"
+	"github.com/gringolito/dnsmasq-manager/pkg/model"
 )
 
 type Service interface {

--- a/release.go
+++ b/release.go
@@ -4,5 +4,5 @@ package main
 
 func init() {
 	BuildMode = "Release"
-	OpenApiSpecFile = "/usr/share/pi-hole-manager/spec/openapi.yaml"
+	OpenApiSpecFile = "/usr/share/dnsmasq-manager/spec/openapi.yaml"
 }

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -6,26 +6,26 @@ install() {
     # even if you want your service to run as non root.
     if [ "${systemd_version}" -lt 231 ]; then
         printf "\033[31m  systemd version %s is less then 231, fixing the service file \033[0m\n" "${systemd_version}"
-        sed -i "s/=+/=/g" /etc/systemd/system/pi-hole-manager.service
+        sed -i "s/=+/=/g" /etc/systemd/system/dnsmasq-manager.service
     fi
     systemctl daemon-reload ||:
-    systemctl unmask pi-hole-manager.service ||:
-    systemctl preset pi-hole-manager.service ||:
-    systemctl enable pi-hole-manager.service ||:
+    systemctl unmask dnsmasq-manager.service ||:
+    systemctl preset dnsmasq-manager.service ||:
+    systemctl enable dnsmasq-manager.service ||:
     printf "\n"
-    printf "  pi-hole-manager service is enabled to start on the next system boot but it is not set to start automatically upon installation.\n"
+    printf "  dnsmasq-manager service is enabled to start on the next system boot but it is not set to start automatically upon installation.\n"
     printf "\n"
     printf "  Please check the security configuration in:\n"
-    printf "    /etc/pi-hole-manager/config.yaml\n"
+    printf "    /etc/dnsmasq-manager/config.yaml\n"
     printf "\n"
     printf "  and start the service with:\n"
-    printf "    systemctl start pi-hole-manager.service\n"
+    printf "    systemctl start dnsmasq-manager.service\n"
     printf "\n"
 }
 
 upgrade() {
-    printf "\033[32m  Reloading pi-hole-manager service\033[0m\n"
-    systemctl try-restart pi-hole-manager.service ||:
+    printf "\033[32m  Reloading dnsmasq-manager service\033[0m\n"
+    systemctl try-restart dnsmasq-manager.service ||:
 }
 
 # Step 2, check if this is a clean install or an upgrade

--- a/scripts/postremove.sh
+++ b/scripts/postremove.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 remove() {
-    systemctl disable pi-hole-manager.service ||:
+    systemctl disable dnsmasq-manager.service ||:
 }
 
 purge() {
-    rm -rf /etc/pi-hole-manager
+    rm -rf /etc/dnsmasq-manager
 }
 
 upgrade() {

--- a/systemd/dnsmasq-manager
+++ b/systemd/dnsmasq-manager
@@ -1,0 +1,4 @@
+# Command line options for dnsmasq-manager.service
+# See also /etc/dnsmasq-manager/config.yaml
+
+ARGS=""

--- a/systemd/dnsmasq-manager.service
+++ b/systemd/dnsmasq-manager.service
@@ -1,6 +1,6 @@
 [Unit]
-Description=Pi-Hole Manager API
-Documentation=https://github.com/gringolito/pi-hole-manager
+Description=Dnsmasq Manager API
+Documentation=https://github.com/gringolito/dnsmasq-manager
 
 # This unit is supposed to indicate when network functionality is available, but it is only
 # very weakly defined what that is supposed to mean, with one exception: at shutdown, a unit
@@ -14,14 +14,14 @@ StartLimitIntervalSec=60s
 
 [Service]
 Type=simple
-EnvironmentFile=/etc/default/pi-hole-manager
+EnvironmentFile=/etc/default/dnsmasq-manager
 User=root
 Group=root
-ExecStart=/usr/bin/pi-hole-manager $ARGS
+ExecStart=/usr/bin/dnsmasq-manager ${ARGS}
 StandardOutput=journal
 Restart=on-failure
 RestartSec=5s
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=/bin/kill -HUP ${MAINPID}
 
 # Use graceful shutdown with a reasonable timeout
 TimeoutStopSec=10s

--- a/systemd/pi-hole-manager
+++ b/systemd/pi-hole-manager
@@ -1,4 +1,0 @@
-# Command line options for pi-hole-manager.service
-# See also /etc/pi-hole-manager/config.yaml
-
-ARGS=""

--- a/test.yaml
+++ b/test.yaml
@@ -1,6 +1,6 @@
 host:
   static:
-    file: ./04-pihole-static-dhcp.conf
+    file: ./04-dhcp-static-leases.conf
 
 auth:
   method: hmac-256


### PR DESCRIPTION
I realized that this project can be more useful if it targets generic dnsmasq servers, instead of being coupled to a Pi-Hole installation, although Pi-Hole FTL has an embedded fully-capable dnsmasq server.

Being used as a standalone dnsmasq management API allows us to support some native dnsmasq functionalities that are not supported by and may conflict with the Pi-Hole's GUI.