### PR TITLE
Initial unit-tests for static host handler

### DIFF
--- a/api/presenter/error.go
+++ b/api/presenter/error.go
@@ -13,6 +13,9 @@ type errorMessage struct {
 	Details interface{} `json:"details"`
 }
 
+const ServerErrorMessage = "An error occurred on the server."
+const InternalServerError = "An internal server error occurred. Please contact the administrator and provide the following request ID: %s."
+
 func ErrorResponse(c *fiber.Ctx, httpStatus int, message string, details interface{}) error {
 	return c.Status(httpStatus).JSON(errorMessage{
 		Error:   http.StatusText(httpStatus),
@@ -23,10 +26,7 @@ func ErrorResponse(c *fiber.Ctx, httpStatus int, message string, details interfa
 
 func InternalServerErrorResponse(c *fiber.Ctx) error {
 	requestId := c.Locals("requestid").(string)
-
-	return ErrorResponse(c, http.StatusInternalServerError,
-		"An error occurred on the server.",
-		fmt.Sprintf("An internal server error occurred. Please contact the administrator and provide the following request ID: %s.", requestId))
+	return ErrorResponse(c, http.StatusInternalServerError, ServerErrorMessage, fmt.Sprintf(InternalServerError, requestId))
 }
 
 func UnprocessableEntityResponse(c *fiber.Ctx, message string, details interface{}) error {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gofiber/fiber/v2 v2.47.0
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/spf13/viper v1.15.0
+	github.com/stretchr/testify v1.8.2
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 )
 
@@ -17,6 +18,7 @@ require (
 	github.com/MicahParks/keyfunc/v2 v2.1.0 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect
 	github.com/go-openapi/errors v0.20.3 // indirect
@@ -42,6 +44,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
 	github.com/savsgio/dictpool v0.0.0-20221023140959-7bf2e61cea94 // indirect
 	github.com/savsgio/gotils v0.0.0-20230208104028-c358bd845dee // indirect
@@ -49,6 +52,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,7 @@ github.com/spf13/viper v1.15.0/go.mod h1:fFcTBJxvhhzSJiZy8n+PeW6t8l+KeT/uTARa0jH
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -310,6 +311,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=

--- a/pkg/host/mock/mock_repository.go
+++ b/pkg/host/mock/mock_repository.go
@@ -1,0 +1,73 @@
+package hostmock
+
+import (
+	"net"
+
+	"github.com/gringolito/dnsmasq-manager/pkg/model"
+	"github.com/stretchr/testify/mock"
+)
+
+type RepositoryMock struct {
+	mock.Mock
+}
+
+func (m *RepositoryMock) Delete(host *model.StaticDhcpHost) (*model.StaticDhcpHost, error) {
+	args := m.Called(host)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *RepositoryMock) DeleteByMac(macAddress net.HardwareAddr) (*model.StaticDhcpHost, error) {
+	args := m.Called(macAddress)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *RepositoryMock) DeleteByIP(ipAddress net.IP) (*model.StaticDhcpHost, error) {
+	args := m.Called(ipAddress)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *RepositoryMock) Find(host *model.StaticDhcpHost) (*model.StaticDhcpHost, error) {
+	args := m.Called(host)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *RepositoryMock) FindAll() (*[]model.StaticDhcpHost, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*[]model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *RepositoryMock) FindByMac(macAddress net.HardwareAddr) (*model.StaticDhcpHost, error) {
+	args := m.Called(macAddress)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *RepositoryMock) FindByIP(ipAddress net.IP) (*model.StaticDhcpHost, error) {
+	args := m.Called(ipAddress)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *RepositoryMock) Save(host *model.StaticDhcpHost) error {
+	args := m.Called(host)
+	return args.Error(0)
+}

--- a/pkg/host/mock/mock_service.go
+++ b/pkg/host/mock/mock_service.go
@@ -1,0 +1,62 @@
+package hostmock
+
+import (
+	"net"
+
+	"github.com/gringolito/dnsmasq-manager/pkg/model"
+	"github.com/stretchr/testify/mock"
+)
+
+type ServiceMock struct {
+	mock.Mock
+}
+
+func (m *ServiceMock) Insert(host *model.StaticDhcpHost) error {
+	args := m.Called(host)
+	return args.Error(0)
+}
+
+func (m *ServiceMock) Update(host *model.StaticDhcpHost) error {
+	args := m.Called(host)
+	return args.Error(0)
+}
+
+func (m *ServiceMock) FetchAll() (*[]model.StaticDhcpHost, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*[]model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *ServiceMock) FetchByIP(ipAddress net.IP) (*model.StaticDhcpHost, error) {
+	args := m.Called(ipAddress)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *ServiceMock) FetchByMac(macAddress net.HardwareAddr) (*model.StaticDhcpHost, error) {
+	args := m.Called(macAddress)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *ServiceMock) RemoveByIP(ipAddress net.IP) (*model.StaticDhcpHost, error) {
+	args := m.Called(ipAddress)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StaticDhcpHost), args.Error(1)
+}
+
+func (m *ServiceMock) RemoveByMac(macAddress net.HardwareAddr) (*model.StaticDhcpHost, error) {
+	args := m.Called(macAddress)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StaticDhcpHost), args.Error(1)
+}

--- a/pkg/host/service.go
+++ b/pkg/host/service.go
@@ -16,6 +16,7 @@ type Service interface {
 	RemoveByIP(ipAddress net.IP) (*model.StaticDhcpHost, error)
 	RemoveByMac(macAddress net.HardwareAddr) (*model.StaticDhcpHost, error)
 }
+
 type service struct {
 	repository Repository
 }

--- a/tests/host_api_test.go
+++ b/tests/host_api_test.go
@@ -1,0 +1,467 @@
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gringolito/dnsmasq-manager/api/handler"
+	"github.com/gringolito/dnsmasq-manager/api/presenter"
+	"github.com/gringolito/dnsmasq-manager/pkg/host"
+	hostmock "github.com/gringolito/dnsmasq-manager/pkg/host/mock"
+	"github.com/gringolito/dnsmasq-manager/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	InvalidMACAddress     = "ab:cd:ef:gh:ij:kl"
+	ValidMACAddress       = "aa:bb:cc:dd:ee:ff"
+	InvalidIPAddress      = "1111"
+	ValidIPAddress        = "1.1.1.1"
+	InvalidHostName       = "B@r"
+	ValidHostJSON         = `{"HostName":"Foo", "IPAddress":"1.1.1.1", "MacAddress":"aa:bb:cc:dd:ee:ff"}`
+	InvalidJSON           = `"HostName":"Foo", "IPAddress":"1.1.1.1", "MacAddress":"aa:bb:cc:dd:ee:ff"`
+	MissingMACAddressJSON = `{"HostName":"Foo", "IPAddress":"1.1.1.1"}`
+	MissingIPAddressJSON  = `{"HostName":"Foo", "MacAddress":"aa:bb:cc:dd:ee:ff"}`
+	MissingHostNameJSON   = `{"IPAddress":"1.1.1.1", "MacAddress":"aa:bb:cc:dd:ee:ff"}`
+	InvalidMACAddressJSON = `{"HostName":"Foo", "IPAddress":"1.1.1.1", "MacAddress":"ab:cd:ef:gh:ij:kl"}`
+	InvalidIPAddressJSON  = `{"HostName":"Foo", "IPAddress":"1111", "MacAddress":"aa:bb:cc:dd:ee:ff"}`
+	InvalidHostNameJSON   = `{"HostName":"B@r", "IPAddress":"1.1.1.1", "MacAddress":"aa:bb:cc:dd:ee:ff"}`
+)
+
+var ValidHost = model.StaticDhcpHost{MacAddress: ParseMAC(ValidMACAddress), IPAddress: net.ParseIP(ValidIPAddress), HostName: "Foo"}
+
+func ParseMAC(macAddress string) net.HardwareAddr {
+	mac, _ := net.ParseMAC(macAddress)
+	return mac
+}
+
+var voidMock = func(mock *hostmock.ServiceMock) {}
+
+var testCases = []struct {
+	name               string
+	httpMethod         string
+	route              string
+	requestBody        io.Reader
+	expectedStatusCode int
+	expectedResponse   string
+	mockSetup          func(s *hostmock.ServiceMock)
+}{
+	{
+		name:               "GetAllStaticHostsSuccess",
+		httpMethod:         http.MethodGet,
+		route:              "/api/v1/static/hosts",
+		expectedStatusCode: http.StatusOK,
+		expectedResponse: `[
+			{
+				"MacAddress":"02:04:06:aa:bb:cc",
+				"IPAddress":"1.1.1.1",
+				"HostName":"Foo"
+			},
+			{
+				"MacAddress":"02:04:06:dd:ee:ff",
+				"IPAddress":"2.2.2.2",
+				"HostName":"Bar"
+			}
+		]`,
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("FetchAll").Once().Return(&[]model.StaticDhcpHost{
+				{MacAddress: ParseMAC("02:04:06:aa:bb:cc"), IPAddress: net.ParseIP("1.1.1.1"), HostName: "Foo"},
+				{MacAddress: ParseMAC("02:04:06:dd:ee:ff"), IPAddress: net.ParseIP("2.2.2.2"), HostName: "Bar"},
+			}, nil)
+		},
+	},
+	{
+		name:               "GetAllStaticHostsServiceError",
+		httpMethod:         http.MethodGet,
+		route:              "/api/v1/static/hosts",
+		expectedStatusCode: http.StatusInternalServerError,
+		expectedResponse:   ErrorJSON(http.StatusInternalServerError, presenter.ServerErrorMessage, fmt.Sprintf(presenter.InternalServerError, UUIDRegexMatch)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("FetchAll").Once().Return(nil, errors.New("an error"))
+		},
+	},
+	{
+		name:               "GetStaticHostNoQueryParameter",
+		httpMethod:         http.MethodGet,
+		route:              "/api/v1/static/host",
+		expectedStatusCode: http.StatusBadRequest,
+		expectedResponse:   ErrorJSON(http.StatusBadRequest, handler.InvalidRequestMessage, handler.MissingQueryParameter),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "GetStaticHostByMACSuccess",
+		httpMethod:         http.MethodGet,
+		route:              fmt.Sprintf("/api/v1/static/host?mac=%s", ValidMACAddress),
+		expectedStatusCode: http.StatusOK,
+		expectedResponse:   ValidHostJSON,
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("FetchByMac", ParseMAC(ValidMACAddress)).Once().Return(&ValidHost, nil)
+		},
+	},
+	{
+		name:               "GetStaticHostInvalidMACAddress",
+		httpMethod:         http.MethodGet,
+		route:              fmt.Sprintf("/api/v1/static/host?mac=%s", InvalidMACAddress),
+		expectedStatusCode: http.StatusBadRequest,
+		expectedResponse:   ErrorJSON(http.StatusBadRequest, handler.InvalidMacAddressMessage, fmt.Sprintf(handler.MalformedMacAddress, InvalidMACAddress)),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "GetStaticHostByMACNotFound",
+		httpMethod:         http.MethodGet,
+		route:              fmt.Sprintf("/api/v1/static/host?mac=%s", ValidMACAddress),
+		expectedStatusCode: http.StatusNotFound,
+		expectedResponse:   ErrorJSON(http.StatusNotFound, handler.StaticHostNotFoundMessage, fmt.Sprintf(handler.NoMatchingMacAddress, ValidMACAddress)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("FetchByMac", ParseMAC(ValidMACAddress)).Once().Return(nil, nil)
+		},
+	},
+	{
+		name:               "GetStaticHostByMACServiceError",
+		httpMethod:         http.MethodGet,
+		route:              fmt.Sprintf("/api/v1/static/host?mac=%s", ValidMACAddress),
+		expectedStatusCode: http.StatusInternalServerError,
+		expectedResponse:   ErrorJSON(http.StatusInternalServerError, presenter.ServerErrorMessage, fmt.Sprintf(presenter.InternalServerError, UUIDRegexMatch)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("FetchByMac", ParseMAC(ValidMACAddress)).Once().Return(nil, errors.New("an error"))
+		},
+	},
+	{
+		name:               "GetStaticHostByIPSuccess",
+		httpMethod:         http.MethodGet,
+		route:              fmt.Sprintf("/api/v1/static/host?ip=%s", ValidIPAddress),
+		expectedStatusCode: http.StatusOK,
+		expectedResponse:   ValidHostJSON,
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("FetchByIP", net.ParseIP(ValidIPAddress)).Once().Return(&ValidHost, nil)
+		},
+	},
+	{
+		name:               "GetStaticHostByIPNotFound",
+		httpMethod:         http.MethodGet,
+		route:              fmt.Sprintf("/api/v1/static/host?ip=%s", ValidIPAddress),
+		expectedStatusCode: http.StatusNotFound,
+		expectedResponse:   ErrorJSON(http.StatusNotFound, handler.StaticHostNotFoundMessage, fmt.Sprintf(handler.NoMatchingIPAddress, ValidIPAddress)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("FetchByIP", net.ParseIP(ValidIPAddress)).Once().Return(nil, nil)
+		},
+	},
+	{
+		name:               "GetStaticHostByIPServiceError",
+		httpMethod:         http.MethodGet,
+		route:              fmt.Sprintf("/api/v1/static/host?ip=%s", ValidIPAddress),
+		expectedStatusCode: http.StatusInternalServerError,
+		expectedResponse:   ErrorJSON(http.StatusInternalServerError, presenter.ServerErrorMessage, fmt.Sprintf(presenter.InternalServerError, UUIDRegexMatch)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("FetchByIP", net.ParseIP(ValidIPAddress)).Once().Return(nil, errors.New("an error"))
+		},
+	},
+	{
+		name:               "PostStaticHostSuccess",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(ValidHostJSON),
+		expectedStatusCode: http.StatusCreated,
+		expectedResponse:   ValidHostJSON,
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("Insert", &ValidHost).Once().Return(nil)
+		},
+	},
+	{
+		name:               "PostStaticHostInvalidJSON",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(InvalidJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ErrorJSON(http.StatusUnprocessableEntity, handler.InvalidRequestBodyMessage, handler.HostCouldNotBeParsed),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PostStaticHostMissingMACAddress",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(MissingMACAddressJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("MacAddress", "The MacAddress field is required.", ""),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PostStaticHostMissingIPAddress",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(MissingIPAddressJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("IPAddress", "The IPAddress field is required.", ""),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PostStaticHostMissingHostName",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(MissingHostNameJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("HostName", "The HostName field is required.", ""),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PostStaticHostInvalidMACAddress",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(InvalidMACAddressJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("MacAddress", "The MacAddress field must be of type mac.", InvalidMACAddress),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PostStaticHostInvalidIPAddress",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(InvalidIPAddressJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("IPAddress", "The IPAddress field must be of type ipv4.", InvalidIPAddress),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PostStaticHostInvalidHostName",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(InvalidHostNameJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("HostName", "The HostName field must be of type hostname.", InvalidHostName),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PostStaticHostDuplicatedIPAddress",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(ValidHostJSON),
+		expectedStatusCode: http.StatusConflict,
+		expectedResponse:   ErrorJSON(http.StatusConflict, handler.DuplicatedIPAddressMessage, fmt.Sprintf(handler.IPAddressAlreadyInUse, ValidIPAddress)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("Insert", &ValidHost).Once().Return(host.DuplicatedEntryError{Field: "IP", Value: ValidIPAddress})
+		},
+	},
+	{
+		name:               "PostStaticHostDuplicatedMACAddress",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(ValidHostJSON),
+		expectedStatusCode: http.StatusConflict,
+		expectedResponse:   ErrorJSON(http.StatusConflict, handler.DuplicatedMacAddressMessage, fmt.Sprintf(handler.MacAddressAlreadyInUse, ValidMACAddress)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("Insert", &ValidHost).Once().Return(host.DuplicatedEntryError{Field: "MAC", Value: ValidMACAddress})
+		},
+	},
+	{
+		name:               "PostStaticHostServiceError",
+		httpMethod:         http.MethodPost,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(ValidHostJSON),
+		expectedStatusCode: http.StatusInternalServerError,
+		expectedResponse:   ErrorJSON(http.StatusInternalServerError, presenter.ServerErrorMessage, fmt.Sprintf(presenter.InternalServerError, UUIDRegexMatch)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("Insert", &ValidHost).Once().Return(errors.New("an error"))
+		},
+	},
+	{
+		name:               "PutStaticHostSuccess",
+		httpMethod:         http.MethodPut,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(ValidHostJSON),
+		expectedStatusCode: http.StatusCreated,
+		expectedResponse:   ValidHostJSON,
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("Update", &ValidHost).Once().Return(nil)
+		},
+	},
+	{
+		name:               "PutStaticHostInvalidJSON",
+		httpMethod:         http.MethodPut,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(InvalidJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ErrorJSON(http.StatusUnprocessableEntity, handler.InvalidRequestBodyMessage, handler.HostCouldNotBeParsed),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PutStaticHostMissingMACAddress",
+		httpMethod:         http.MethodPut,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(MissingMACAddressJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("MacAddress", "The MacAddress field is required.", ""),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PutStaticHostMissingIPAddress",
+		httpMethod:         http.MethodPut,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(MissingIPAddressJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("IPAddress", "The IPAddress field is required.", ""),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PutStaticHostMissingHostName",
+		httpMethod:         http.MethodPut,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(MissingHostNameJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("HostName", "The HostName field is required.", ""),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PutStaticHostInvalidMACAddress",
+		httpMethod:         http.MethodPut,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(InvalidMACAddressJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("MacAddress", "The MacAddress field must be of type mac.", InvalidMACAddress),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PutStaticHostInvalidIPAddress",
+		httpMethod:         http.MethodPut,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(InvalidIPAddressJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("IPAddress", "The IPAddress field must be of type ipv4.", InvalidIPAddress),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PutStaticHostInvalidHostName",
+		httpMethod:         http.MethodPut,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(InvalidHostNameJSON),
+		expectedStatusCode: http.StatusUnprocessableEntity,
+		expectedResponse:   ValidationErrorJSON("HostName", "The HostName field must be of type hostname.", InvalidHostName),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "PutStaticHostServiceError",
+		httpMethod:         http.MethodPut,
+		route:              "/api/v1/static/host",
+		requestBody:        strings.NewReader(ValidHostJSON),
+		expectedStatusCode: http.StatusInternalServerError,
+		expectedResponse:   ErrorJSON(http.StatusInternalServerError, presenter.ServerErrorMessage, fmt.Sprintf(presenter.InternalServerError, UUIDRegexMatch)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("Update", &ValidHost).Once().Return(errors.New("an error"))
+		},
+	},
+	{
+		name:               "DeleteStaticHostNoQueryParameter",
+		httpMethod:         http.MethodDelete,
+		route:              "/api/v1/static/host",
+		expectedStatusCode: http.StatusBadRequest,
+		expectedResponse:   ErrorJSON(http.StatusBadRequest, handler.InvalidRequestMessage, handler.MissingQueryParameter),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "DeleteStaticHostByMACSuccess",
+		httpMethod:         http.MethodDelete,
+		route:              fmt.Sprintf("/api/v1/static/host?mac=%s", ValidMACAddress),
+		expectedStatusCode: http.StatusOK,
+		expectedResponse:   ValidHostJSON,
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("RemoveByMac", ParseMAC(ValidMACAddress)).Once().Return(&ValidHost, nil)
+		},
+	},
+	{
+		name:               "DeleteStaticHostInvalidMACAddress",
+		httpMethod:         http.MethodDelete,
+		route:              fmt.Sprintf("/api/v1/static/host?mac=%s", InvalidMACAddress),
+		expectedStatusCode: http.StatusBadRequest,
+		expectedResponse:   ErrorJSON(http.StatusBadRequest, handler.InvalidMacAddressMessage, fmt.Sprintf(handler.MalformedMacAddress, InvalidMACAddress)),
+		mockSetup:          voidMock,
+	},
+	{
+		name:               "DeleteStaticHostByMACNotFound",
+		httpMethod:         http.MethodDelete,
+		route:              fmt.Sprintf("/api/v1/static/host?mac=%s", ValidMACAddress),
+		expectedStatusCode: http.StatusNoContent,
+		expectedResponse:   "",
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("RemoveByMac", ParseMAC(ValidMACAddress)).Once().Return(nil, nil)
+		},
+	},
+	{
+		name:               "DeleteStaticHostByMACServiceError",
+		httpMethod:         http.MethodDelete,
+		route:              fmt.Sprintf("/api/v1/static/host?mac=%s", ValidMACAddress),
+		expectedStatusCode: http.StatusInternalServerError,
+		expectedResponse:   ErrorJSON(http.StatusInternalServerError, presenter.ServerErrorMessage, fmt.Sprintf(presenter.InternalServerError, UUIDRegexMatch)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("RemoveByMac", ParseMAC(ValidMACAddress)).Once().Return(nil, errors.New("an error"))
+		},
+	},
+	{
+		name:               "DeleteStaticHostByIPSuccess",
+		httpMethod:         http.MethodDelete,
+		route:              fmt.Sprintf("/api/v1/static/host?ip=%s", ValidIPAddress),
+		expectedStatusCode: http.StatusOK,
+		expectedResponse:   ValidHostJSON,
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("RemoveByIP", net.ParseIP(ValidIPAddress)).Once().Return(&ValidHost, nil)
+		},
+	},
+	{
+		name:               "DeleteStaticHostByIPNotFound",
+		httpMethod:         http.MethodDelete,
+		route:              fmt.Sprintf("/api/v1/static/host?ip=%s", ValidIPAddress),
+		expectedStatusCode: http.StatusNoContent,
+		expectedResponse:   "",
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("RemoveByIP", net.ParseIP(ValidIPAddress)).Once().Return(nil, nil)
+		},
+	},
+	{
+		name:               "DeleteStaticHostByIPServiceError",
+		httpMethod:         http.MethodDelete,
+		route:              fmt.Sprintf("/api/v1/static/host?ip=%s", ValidIPAddress),
+		expectedStatusCode: http.StatusInternalServerError,
+		expectedResponse:   ErrorJSON(http.StatusInternalServerError, presenter.ServerErrorMessage, fmt.Sprintf(presenter.InternalServerError, UUIDRegexMatch)),
+		mockSetup: func(mock *hostmock.ServiceMock) {
+			mock.On("RemoveByIP", net.ParseIP(ValidIPAddress)).Once().Return(nil, errors.New("an error"))
+		},
+	},
+}
+
+func setupTest(t *testing.T, mockSetup func(mock *hostmock.ServiceMock)) *fiber.App {
+	app := SetupApp()
+	config := SetupConfig(t)
+	serviceMock := &hostmock.ServiceMock{}
+	router := SetupRouter(app, config)
+	router.HostApi(serviceMock)
+	mockSetup(serviceMock)
+	return app
+}
+
+func TestStaticHostsApi(t *testing.T) {
+	for _, test := range testCases {
+		description := fmt.Sprintf("%s %s %d", test.httpMethod, test.route, test.expectedStatusCode)
+		t.Run(test.name, func(t *testing.T) {
+			app := setupTest(t, test.mockSetup)
+
+			request := httptest.NewRequest(test.httpMethod, test.route, test.requestBody)
+			request.Header.Set("Content-Type", "application/json")
+
+			response, err := app.Test(request)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedStatusCode, response.StatusCode, "%s: returned wrong HTTP status code", description)
+
+			responseBody := GetBody(response)
+			if !JSONMatches(test.expectedResponse, string(responseBody)) {
+				assert.JSONEq(t, test.expectedResponse, string(responseBody), "%s: unexpected HTTP response body", description)
+			}
+		})
+	}
+}

--- a/tests/setup_api.go
+++ b/tests/setup_api.go
@@ -1,0 +1,30 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gringolito/dnsmasq-manager/api"
+	"github.com/gringolito/dnsmasq-manager/config"
+	"github.com/stretchr/testify/require"
+)
+
+func SetupConfig(t *testing.T) *config.Config {
+	configName := "unittest"
+	cfg, err := config.Init(configName)
+	require.NoError(t, err)
+
+	return cfg
+}
+
+func SetupApp() *fiber.App {
+	return fiber.New(fiber.Config{
+		CaseSensitive:     true,
+		EnablePrintRoutes: true,
+	})
+}
+
+func SetupRouter(app *fiber.App, cfg *config.Config) api.Router {
+	middleware, _ := api.NewMiddleware(nil, cfg)
+	return api.NewRouter(app, middleware)
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1,0 +1,98 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+
+	"github.com/gringolito/dnsmasq-manager/api/handler"
+)
+
+const UUIDRegexMatch = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+func UnmarshalJSON(data []byte) (map[string]any, error) {
+	var JSON map[string]any
+	err := json.Unmarshal(data, &JSON)
+	return JSON, err
+}
+
+func GetBody(response *http.Response) []byte {
+	if response.ContentLength == 0 {
+		return nil
+	}
+
+	bodyData := make([]byte, response.ContentLength)
+	_, _ = response.Body.Read(bodyData)
+	return bodyData
+}
+
+func GetBodyJSON(response *http.Response) (map[string]any, error) {
+	return UnmarshalJSON(GetBody(response))
+}
+
+func JSONMatches(expected string, actual string) bool {
+	expectedJSON, _ := UnmarshalJSON([]byte(expected))
+	actualJSON, _ := UnmarshalJSON([]byte(actual))
+	return JSONMapMatches(expectedJSON, actualJSON)
+}
+
+func JSONMapMatches(expected map[string]any, actual map[string]any) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+
+	for key, expected_value := range expected {
+		actual_value, exists := actual[key]
+		if !exists {
+			return false
+		}
+
+		switch v := expected_value.(type) {
+		case []interface{}:
+			for _, expected_inner_value := range v {
+				match := false
+				for _, actual_inner_value := range actual_value.([]interface{}) {
+					if JSONMapMatches(expected_inner_value.(map[string]any), actual_inner_value.(map[string]any)) {
+						match = true
+						break
+					}
+				}
+
+				if !match {
+					return false
+				}
+			}
+		case string:
+			match, _ := regexp.MatchString(v, actual_value.(string))
+			if !match {
+				return false
+			}
+		default:
+			log.Fatalf("Un-expected type: %T", v)
+		}
+	}
+
+	return true
+}
+
+func errorJSON(statusCode int, message string, details string) string {
+	return fmt.Sprintf(`{
+		"error": "%s",
+		"message": "%s",
+		"details": %s
+	}`, http.StatusText(statusCode), message, details)
+}
+
+func ErrorJSON(statusCode int, message string, details string) string {
+	return errorJSON(statusCode, message, fmt.Sprintf(`"%s"`, details))
+}
+
+func ValidationErrorJSON(field string, reason string, value string) string {
+	return errorJSON(http.StatusUnprocessableEntity, handler.InvalidRequestBodyMessage, fmt.Sprintf(`[{
+		"field": "%s",
+		"reason": "%s",
+		"value": "%s"
+	}]`, field, reason, value))
+}


### PR DESCRIPTION
The unit tests started from the host handler using mocks on the service
layer of the architecture. More comprehensive, end-to-end, tests are
planned for later iterations of the development.

Signed-off-by: Filipe Utzig [filipe@gringolito.com](mailto:filipe@gringolito.com)