### PR TITLE
Fix CI workflows triggers

### DIFF
--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -1,5 +1,5 @@
 ---
-name: Build for tags
+name: Build Release
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  build:
     uses: ./.github/workflows/goreleaser.yaml
     with:
       goreleaser-args: release --clean

--- a/.github/workflows/build-snapshots.yaml
+++ b/.github/workflows/build-snapshots.yaml
@@ -1,7 +1,11 @@
 ---
-name: Build for PRs
+name: Build Snapshot
 
 on:
+  push:
+    branches:
+      - master
+      - 'release/v[0-9].[0-9]'
   pull_request:
     branches:
       - master

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,9 @@ on:
   push:
     tags:
       - '*'
+    branches:
+      - master
+      - 'release/v[0-9].[0-9]'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Set the CI workflow triggers to also run whenever new commits are pushed into the `master` or `release/` branches.