### PR TITLE
Add mutex lock in repository saves

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -5,6 +5,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/recover"
 	"github.com/gofiber/fiber/v2/middleware/requestid"
+	"github.com/gofiber/fiber/v2/utils"
+	"github.com/google/uuid"
 	"github.com/gringolito/dnsmasq-manager/api/middleware/fiberslog"
 	"github.com/gringolito/dnsmasq-manager/config"
 	"golang.org/x/exp/slog"
@@ -27,7 +29,10 @@ func NewMiddleware(logger *slog.Logger, cfg *config.Config) (Middleware, error) 
 		recovery: recover.New(recover.Config{
 			EnableStackTrace: true,
 		}),
-		requestId: requestid.New(),
+		requestId: requestid.New(requestid.Config{
+			Generator:  uuidV7,
+			ContextKey: "requestid",
+		}),
 		jwtConfig: jwtConfig,
 	}
 
@@ -39,6 +44,15 @@ func NewMiddleware(logger *slog.Logger, cfg *config.Config) (Middleware, error) 
 	}
 
 	return mw, nil
+}
+
+func uuidV7() string {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return utils.UUID()
+	}
+
+	return id.String()
 }
 
 type middleware struct {

--- a/api/middleware/fiberslog/slog.go
+++ b/api/middleware/fiberslog/slog.go
@@ -1,7 +1,6 @@
 package fiberslog
 
 import (
-	"context"
 	"os"
 	"time"
 
@@ -58,7 +57,7 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		// Log disabled for the current level, short-circuit return
-		if !cfg.Logger.Enabled(context.Background(), logLevel) {
+		if !cfg.Logger.Enabled(c.UserContext(), logLevel) {
 			return err
 		}
 
@@ -126,7 +125,7 @@ func New(config ...Config) fiber.Handler {
 
 		}
 
-		cfg.Logger.LogAttrs(context.Background(), logLevel, logMessage, fields...)
+		cfg.Logger.LogAttrs(c.UserContext(), logLevel, logMessage, fields...)
 
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gofiber/contrib/jwt v1.0.3
 	github.com/gofiber/fiber/v2 v2.47.0
 	github.com/golang-jwt/jwt/v5 v5.0.0
+	github.com/google/uuid v1.6.0
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
@@ -30,7 +31,6 @@ require (
 	github.com/go-openapi/validate v0.22.1 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.16.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,9 @@ github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=

--- a/pkg/host/repository.go
+++ b/pkg/host/repository.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/gringolito/dnsmasq-manager/pkg/model"
 	"golang.org/x/exp/slog"
@@ -24,6 +25,7 @@ type Repository interface {
 
 type repository struct {
 	staticHostsFilePath string
+	mutex               sync.RWMutex
 }
 
 func NewRepository(staticHostsFilePath string) Repository {
@@ -33,22 +35,32 @@ func NewRepository(staticHostsFilePath string) Repository {
 }
 
 func (r *repository) FindAll() (*[]model.StaticDhcpHost, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 	return r.load()
 }
 
 func (r *repository) Find(host *model.StaticDhcpHost) (*model.StaticDhcpHost, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 	return r.find(sameHost(host))
 }
 
 func (r *repository) FindByMac(macAddress net.HardwareAddr) (*model.StaticDhcpHost, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 	return r.find(sameMacAddress(macAddress))
 }
 
 func (r *repository) FindByIP(ipAddress net.IP) (*model.StaticDhcpHost, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 	return r.find(sameIPAddress(ipAddress))
 }
 
 func (r *repository) Save(host *model.StaticDhcpHost) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	hosts, err := r.load()
 	if err != nil {
 		return err
@@ -59,14 +71,20 @@ func (r *repository) Save(host *model.StaticDhcpHost) error {
 }
 
 func (r *repository) Delete(host *model.StaticDhcpHost) (*model.StaticDhcpHost, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	return r.delete(sameHost(host))
 }
 
 func (r *repository) DeleteByMac(macAddress net.HardwareAddr) (*model.StaticDhcpHost, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	return r.delete(sameMacAddress(macAddress))
 }
 
 func (r *repository) DeleteByIP(ipAddress net.IP) (*model.StaticDhcpHost, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	return r.delete(sameIPAddress(ipAddress))
 }
 

--- a/pkg/host/repository.go
+++ b/pkg/host/repository.go
@@ -135,6 +135,10 @@ func (r *repository) save(hosts *[]model.StaticDhcpHost) error {
 	for _, host := range *hosts {
 		hostConfig, err := host.ToConfig()
 		if err != nil {
+			slog.Debug("Invalid static DHCP host",
+				slog.Any("host", host),
+				slog.String("error", err.Error()),
+			)
 			return err
 		}
 		config = append(config, hostConfig)


### PR DESCRIPTION
Concurrent saves were overwriting due to racing conditions on file reads/writes. To avoid those race conditions a R/W mutex was added into the `host.Repository` implementation to sequentiate the concurrent writes on the filesystem.

Also, some improvements to the logging system were made to help debug the issue, such as adopting (ordered) UUIDv7 on the RequestId instead of the previously used UUIDv4.