### PR TITLE
systemd: fix service startup failures on fresh installs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,6 +51,8 @@ nfpms:
     homepage: https://github.com/gringolito/dnsmasq-manager
     description: Dnsmasq DNS / DHCP management external API.
     license: Beer-ware
+    dependencies:
+      - dnsmasq
     formats:
       - deb
       - rpm

--- a/systemd/dnsmasq-manager.service
+++ b/systemd/dnsmasq-manager.service
@@ -92,9 +92,9 @@ NoNewPrivileges=true
 # Disable access / creating of memory mappings that are writable and executable at the same time
 MemoryDenyWriteExecute=true
 
-# Allow only syscalls in group @system-service the those in groups @privileged and @resources
+# Allow only syscalls in group @system-service except those in group @privileged
 SystemCallFilter=@system-service
-SystemCallFilter=~@privileged @resources
+SystemCallFilter=~@privileged
 
 # Allow native calls only
 SystemCallArchitectures=native


### PR DESCRIPTION
## Summary

Two related startup failures are fixed in this PR.

### 1. SIGSYS crash — `setrlimit` blocked by `SystemCallFilter` (`systemd/dnsmasq-manager.service`)

The Go 1.24 runtime calls `setrlimit` (syscall 160) during process initialization — before `main()` runs — to raise the open file descriptor limit. `setrlimit` belongs to the `@resources` syscall group, which was denied via `SystemCallFilter=~@privileged @resources`, causing the kernel to send SIGSYS (signal 31) and kill the service immediately on startup (reported on Debian Trixie).

The fix removes `@resources` from the deny list. The `@resources` group only contains benign resource-limit and scheduling-priority syscalls (`getrlimit`, `setrlimit`, `prlimit64`, `getpriority`, `setpriority`), none of which are dangerous given the existing sandbox. The `@privileged` deny remains in place.

### 2. `EXIT_NAMESPACE` (226) — `/etc/dnsmasq.d/` missing on fresh installs (`.goreleaser.yaml`)

`ProtectSystem=strict` bind-mounts every path in `ReadWritePaths=` before executing the service binary. If `/etc/dnsmasq.d/` doesn't exist (i.e. dnsmasq was never installed), the mount namespace setup fails with status `226/NAMESPACE`.

The fix declares `dnsmasq` as a hard package dependency so the package manager always installs dnsmasq first — dnsmasq's own package creates `/etc/dnsmasq.d/`, ensuring the directory is present when the service starts.

Closes #20