### PR TITLE
fix: validate IP address before service call in host handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ dist/
 # JWT signing keys
 *.pem
 *.pub
+
+# Status tracking
+.tracking/

--- a/api/handler/host_handler.go
+++ b/api/handler/host_handler.go
@@ -22,6 +22,7 @@ const (
 	InvalidRequestMessage       = "The request is invalid."
 	InvalidRequestBodyMessage   = "The request body was invalid."
 	InvalidMacAddressMessage    = "The MAC address is invalid."
+	InvalidIPAddressMessage     = "The IP address is invalid."
 	DuplicatedMacAddressMessage = "A host with the same MAC address already exists."
 	DuplicatedIPAddressMessage  = "The IP address is already in use."
 )
@@ -38,6 +39,8 @@ const (
 		"Please specify one of these parameters in order to proceed."
 	MalformedMacAddress = "The MAC address that was provided is not in the correct format. " +
 		"Please check the format of the MAC address and try again. The MAC address that was provided was: %s."
+	MalformedIPAddress = "The IP address that was provided is not in the correct format. " +
+		"Please check the format of the IP address and try again. The IP address that was provided was: %s."
 	IPAddressAlreadyInUse = "The IP address that was provided is already in use by another host. " +
 		"Please try again with a different IP address. The IP address that was provided was: %s."
 	MacAddressAlreadyInUse = "The MAC address that was provided is already in use by another host: %s."
@@ -120,7 +123,15 @@ func getStaticHostByMac(service host.Service, c *fiber.Ctx, macAddress string) e
 }
 
 func getStaticHostByIP(service host.Service, c *fiber.Ctx, ipAddress string) error {
-	host, err := service.FetchByIP(net.ParseIP(ipAddress))
+	ip := net.ParseIP(ipAddress)
+	if ip == nil {
+		slog.Debug("Could not parse IP address",
+			slog.String("ipAddress", ipAddress),
+		)
+		return presenter.BadRequestResponse(c, InvalidIPAddressMessage, fmt.Sprintf(MalformedIPAddress, ipAddress))
+	}
+
+	host, err := service.FetchByIP(ip)
 	if err != nil {
 		return presenter.InternalServerErrorResponse(c)
 	}
@@ -213,7 +224,15 @@ func removeStaticHostByMac(service host.Service, c *fiber.Ctx, macAddress string
 }
 
 func removeStaticHostByIP(service host.Service, c *fiber.Ctx, ipAddress string) error {
-	host, err := service.RemoveByIP(net.ParseIP(ipAddress))
+	ip := net.ParseIP(ipAddress)
+	if ip == nil {
+		slog.Debug("Could not parse IP address",
+			slog.String("ipAddress", ipAddress),
+		)
+		return presenter.BadRequestResponse(c, InvalidIPAddressMessage, fmt.Sprintf(MalformedIPAddress, ipAddress))
+	}
+
+	host, err := service.RemoveByIP(ip)
 	if err != nil {
 		return presenter.InternalServerErrorResponse(c)
 	}

--- a/api/handler/host_handler_test.go
+++ b/api/handler/host_handler_test.go
@@ -163,6 +163,14 @@ func TestStaticHostsApi(t *testing.T) {
 			},
 		},
 		{
+			name:               "GetStaticHostByIPInvalidIPAddress",
+			httpMethod:         http.MethodGet,
+			route:              fmt.Sprintf("/api/v1/static/host?ip=%s", InvalidIPAddress),
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   tests.ErrorJSON(http.StatusBadRequest, InvalidIPAddressMessage, fmt.Sprintf(MalformedIPAddress, InvalidIPAddress)),
+			mockSetup:          voidMock,
+		},
+		{
 			name:               "GetStaticHostByIPSuccess",
 			httpMethod:         http.MethodGet,
 			route:              fmt.Sprintf("/api/v1/static/host?ip=%s", ValidIPAddress),
@@ -429,6 +437,14 @@ func TestStaticHostsApi(t *testing.T) {
 			mockSetup: func(mock *hostmock.ServiceMock) {
 				mock.On("RemoveByMac", tests.ParseMAC(ValidMACAddress)).Once().Return(nil, errors.New("an error"))
 			},
+		},
+		{
+			name:               "DeleteStaticHostByIPInvalidIPAddress",
+			httpMethod:         http.MethodDelete,
+			route:              fmt.Sprintf("/api/v1/static/host?ip=%s", InvalidIPAddress),
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   tests.ErrorJSON(http.StatusBadRequest, InvalidIPAddressMessage, fmt.Sprintf(MalformedIPAddress, InvalidIPAddress)),
+			mockSetup:          voidMock,
 		},
 		{
 			name:               "DeleteStaticHostByIPSuccess",


### PR DESCRIPTION
## Summary

- `net.ParseIP()` returns `nil` for invalid input; in `getStaticHostByIP()` and `removeStaticHostByIP()` the result was passed unchecked to the service layer, which called `.Equal()` on a nil `net.IP` and panicked
- The recovery middleware caught the panic and returned 500, masking the root cause
- Affected routes: `GET /api/v1/static/host?ip=<invalid>` and `DELETE /api/v1/static/host?ip=<invalid>`
- Fix adds a nil check after `net.ParseIP()` and returns `400 Bad Request`, matching the pattern already used for MAC address validation in the same file