### PR TITLE
fix: return 403 on missing or non-string JWT name claim

### DIFF
--- a/api/authorization.go
+++ b/api/authorization.go
@@ -20,7 +20,10 @@ func authorizationHandler(jwtContextKey string, roles []string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		token := c.Locals(jwtContextKey).(*jwt.Token)
 		claims := token.Claims.(jwt.MapClaims)
-		name := claims["name"].(string)
+		name, ok := claims["name"].(string)
+		if !ok {
+			return presenter.ForbiddenResponse(c, NotAuthorizedMessage, MalformedJwt)
+		}
 
 		scopes, err := parseClaimScope(claims)
 		if err != nil {

--- a/api/handler/host_handler_test.go
+++ b/api/handler/host_handler_test.go
@@ -554,6 +554,37 @@ func TestStaticHostsApiWithAuth(t *testing.T) {
 			mockSetup:          voidMock,
 		},
 		{
+			name:       "GetAllMissingNameClaimJWT",
+			httpMethod: http.MethodGet,
+			route:      "/api/v1/static/hosts",
+			token: &jwtTokenConfig{
+				SigningKey: AuthKey,
+				Claims: jwt.MapClaims{
+					"exp":   time.Now().Add(time.Minute * 30).Unix(),
+					"scope": scope.DhcpRead,
+				},
+			},
+			expectedStatusCode: http.StatusForbidden,
+			expectedResponse:   tests.ErrorJSON(http.StatusForbidden, api.NotAuthorizedMessage, api.MalformedJwt),
+			mockSetup:          voidMock,
+		},
+		{
+			name:       "GetAllNonStringNameClaimJWT",
+			httpMethod: http.MethodGet,
+			route:      "/api/v1/static/hosts",
+			token: &jwtTokenConfig{
+				SigningKey: AuthKey,
+				Claims: jwt.MapClaims{
+					"name":  42,
+					"exp":   time.Now().Add(time.Minute * 30).Unix(),
+					"scope": scope.DhcpRead,
+				},
+			},
+			expectedStatusCode: http.StatusForbidden,
+			expectedResponse:   tests.ErrorJSON(http.StatusForbidden, api.NotAuthorizedMessage, api.MalformedJwt),
+			mockSetup:          voidMock,
+		},
+		{
 			name:       "GetAllAuthorized",
 			httpMethod: http.MethodGet,
 			route:      "/api/v1/static/hosts",


### PR DESCRIPTION
## Summary

- `claims["name"].(string)` in `api/authorization.go` was an unchecked type assertion that panicked when the `name` claim was absent or a non-string type (e.g. integer)
- The recover middleware silently swallowed the panic and returned 500 instead of 403
- Replaced with a two-value assertion; returns `403 Forbidden` with `MalformedJwt` detail when the assertion fails