### PR TITLE
fix: return 500 with "unknown" fallback on missing requestid locals

### DIFF
--- a/api/presenter/error.go
+++ b/api/presenter/error.go
@@ -25,7 +25,10 @@ func ErrorResponse(c *fiber.Ctx, httpStatus int, message string, details interfa
 }
 
 func InternalServerErrorResponse(c *fiber.Ctx) error {
-	requestId := c.Locals("requestid").(string)
+	requestId, ok := c.Locals("requestid").(string)
+	if !ok {
+		requestId = "unknown"
+	}
 	return ErrorResponse(c, http.StatusInternalServerError, ServerErrorMessage, fmt.Sprintf(InternalServerError, requestId))
 }
 

--- a/api/presenter/error_test.go
+++ b/api/presenter/error_test.go
@@ -1,0 +1,61 @@
+package presenter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInternalServerErrorResponseWithoutRequestId(t *testing.T) {
+	app := fiber.New()
+	app.Get("/test", func(c *fiber.Ctx) error {
+		return InternalServerErrorResponse(c)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &result))
+	assert.Equal(t, http.StatusText(http.StatusInternalServerError), result["error"])
+	assert.Equal(t, ServerErrorMessage, result["message"])
+	assert.Equal(t, fmt.Sprintf(InternalServerError, "unknown"), result["details"])
+}
+
+func TestInternalServerErrorResponseWithRequestId(t *testing.T) {
+	const testRequestId = "550e8400-e29b-41d4-a716-446655440000"
+
+	app := fiber.New()
+	app.Get("/test", func(c *fiber.Ctx) error {
+		c.Locals("requestid", testRequestId)
+		return InternalServerErrorResponse(c)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &result))
+	assert.Equal(t, http.StatusText(http.StatusInternalServerError), result["error"])
+	assert.Equal(t, ServerErrorMessage, result["message"])
+	assert.Equal(t, fmt.Sprintf(InternalServerError, testRequestId), result["details"])
+}


### PR DESCRIPTION
## Summary

- `c.Locals("requestid").(string)` in `InternalServerErrorResponse` panicked whenever the requestid middleware had not run (e.g. a route outside the `/api` group, future refactors, or tests bypassing the stack)
- Replaced the unchecked assertion with a two-value check; falls back to `"unknown"` so a well-formed 500 JSON response is always returned
- Adds `api/presenter/error_test.go` with two direct unit tests — one that reproduces the panic (fails before fix, passes after) and one regression guard for the normal requestid path