### PR TITLE
feat: warn at startup when authentication is disabled

### DIFF
--- a/api/authentication.go
+++ b/api/authentication.go
@@ -24,6 +24,9 @@ const (
 
 func setupJwtConfig(cfg *config.Config) (*jwtware.Config, error) {
 	if cfg.Auth.Method == config.NoAuth {
+		slog.Warn("Authentication is disabled! All API endpoints are publicly accessible without authentication.",
+			slog.String("auth.method", cfg.Auth.Method),
+		)
 		return nil, nil
 	}
 

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -1,0 +1,61 @@
+package api_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gringolito/dnsmasq-manager/api"
+	"github.com/gringolito/dnsmasq-manager/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slog"
+)
+
+func TestNewMiddlewareAuthDisabledWarning(t *testing.T) {
+	tests := []struct {
+		name       string
+		authMethod string
+		authKey    string
+		expectWarn bool
+	}{
+		{
+			name:       "NoAuth emits WARN",
+			authMethod: config.NoAuth,
+			authKey:    "",
+			expectWarn: true,
+		},
+		{
+			name:       "Configured auth emits no WARN",
+			authMethod: config.AuthHS256,
+			authKey:    "test-secret-key",
+			expectWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+			originalLogger := slog.Default()
+			slog.SetDefault(slog.New(handler))
+			t.Cleanup(func() { slog.SetDefault(originalLogger) })
+
+			cfg := &config.Config{}
+			cfg.Auth.Method = tt.authMethod
+			cfg.Auth.Key = tt.authKey
+
+			mw, err := api.NewMiddleware(nil, cfg)
+
+			require.NoError(t, err)
+			assert.NotNil(t, mw)
+
+			logOutput := buf.String()
+			if tt.expectWarn {
+				assert.Contains(t, logOutput, "WARN")
+				assert.Contains(t, logOutput, "Authentication is disabled")
+			} else {
+				assert.NotContains(t, logOutput, "WARN")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `slog.Warn` call in `setupJwtConfig()` (`api/authentication.go`) when `Auth.Method` is `"none"` (the default), so operators are immediately alerted that all API endpoints are publicly accessible without any authentication
- Adds `api/middleware_test.go` with a table-driven test (`TestNewMiddlewareAuthDisabledWarning`) that verifies the warning is emitted for `NoAuth` and suppressed when a real auth method is configured