### PR TITLE
fix: warn at startup when config file is not found

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/spf13/viper"
+	"golang.org/x/exp/slog"
 )
 
 // Auth.Method constants
@@ -86,7 +87,9 @@ func Init(configName string) (*Config, error) {
 	err := v.ReadInConfig()
 	if err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			// Config file not found; ignore error, parse environments and load defaults
+			slog.Warn("No configuration file found, running with defaults",
+				slog.String("config.name", configName),
+			)
 		} else {
 			return nil, err
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,61 @@
+package config_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/gringolito/dnsmasq-manager/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slog"
+)
+
+const testConfigName = "dmm-test-config"
+
+func TestInitConfigFileNotFoundWarning(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupConfigFile bool
+		expectWarn      bool
+	}{
+		{
+			name:            "Config file not found emits WARN",
+			setupConfigFile: false,
+			expectWarn:      true,
+		},
+		{
+			name:            "Config file found emits no WARN",
+			setupConfigFile: true,
+			expectWarn:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+			originalLogger := slog.Default()
+			slog.SetDefault(slog.New(handler))
+			t.Cleanup(func() { slog.SetDefault(originalLogger) })
+
+			if tt.setupConfigFile {
+				err := os.WriteFile(testConfigName+".yaml", []byte("# minimal test config\n"), 0644)
+				require.NoError(t, err, "Failed to create test config file")
+				t.Cleanup(func() { os.Remove(testConfigName + ".yaml") })
+			}
+
+			cfg, err := config.Init(testConfigName)
+			require.NoError(t, err)
+			assert.NotNil(t, cfg)
+
+			logOutput := buf.String()
+			if tt.expectWarn {
+				assert.Contains(t, logOutput, "WARN")
+				assert.Contains(t, logOutput, "No configuration file found, running with defaults")
+			} else {
+				assert.NotContains(t, logOutput, "WARN")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Missing config file caused silent startup with insecure defaults (no auth, default file paths) with no operator visibility
- Emit `slog.Warn` inside the `viper.ConfigFileNotFoundError` branch of `config.Init()` so the condition is always visible in logs
- Adds `config/config_test.go` with table-driven tests (red before fix, green after) using the same slog buffer-capture pattern as `api/middleware_test.go`