### PR TITLE
ci: update GitHub Actions and skip Codecov on Dependabot PRs

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -21,25 +21,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ./go.mod
           check-latest: true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           args: ${{ inputs.goreleaser-args }}
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dnsmasq-manager-${{ github.sha }}
           path: ./dist/*

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ./go.mod
           check-latest: true
@@ -35,7 +35,8 @@ jobs:
         run: go tool cover -func coverage.out
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: codecov/codecov-action@v6
         with:
           name: dnsmasq-manager
           file: ./coverage.out


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` to v6, `actions/setup-go` to v6
- Bump `goreleaser/goreleaser-action` to v7, `actions/upload-artifact` to v7
- Bump `codecov/codecov-action` to v6
- Skip Codecov upload step when the job is triggered by `dependabot[bot]` (Dependabot lacks access to repository secrets)